### PR TITLE
Add support to export orders in csv file format in the admin site.

### DIFF
--- a/myshop/orders/admin.py
+++ b/myshop/orders/admin.py
@@ -1,3 +1,6 @@
+import csv
+import datetime
+from django.http import HttpResponse
 from django.contrib import admin
 from .models import Order, OrderItem
 
@@ -5,6 +8,33 @@ from .models import Order, OrderItem
 class OrderItemInline(admin.TabularInline):
     model = OrderItem
     raw_id_fields = ["product"]
+
+
+def export_to_csv(modeladmin, request, queryset):
+    opts = modeladmin.model._meta
+    content_disposition = f"attachment; filename={opts.verbose_name}.csv"
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = content_disposition
+    writer = csv.writer(response)
+
+    fields = [
+        field
+        for field in opts.get_fields()
+        if not field.many_to_many and not field.one_to_many
+    ]
+    writer.writerow([field.verbose_name for field in fields])
+    for obj in queryset:
+        data_row = []
+        for field in fields:
+            value = getattr(obj, field.name)
+            if isinstance(value, datetime.datetime):
+                value = value.strftime("%d/%m/%Y")
+            data_row.append(value)
+        writer.writerow(data_row)
+    return response
+
+
+export_to_csv.short_description = "Export to CSV"
 
 
 @admin.register(Order)
@@ -22,4 +52,5 @@ class OrderAdmin(admin.ModelAdmin):
         "updated",
     ]
     list_filter = ["paid", "created", "updated"]
+    actions = [export_to_csv]
     inlines = [OrderItemInline]


### PR DESCRIPTION
- Customized to the admin site to allow the staff to download orders in CSV files format.